### PR TITLE
chore: update to remix 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@remix-run/server-runtime": "^1.0.0"
+    "@remix-run/server-runtime": "^1 || ^2"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",


### PR DESCRIPTION
This allows the package to be used in remix v2 setups.